### PR TITLE
Updated Text & Hazzat responses to replace common & reason references

### DIFF
--- a/src/Common/Types/Language.ts
+++ b/src/Common/Types/Language.ts
@@ -1,0 +1,5 @@
+export enum Language {
+    English = "English",
+    Coptic = "Coptic",
+    Arabic = "Arabic"
+}

--- a/src/DataProviders/IDataProvider.ts
+++ b/src/DataProviders/IDataProvider.ts
@@ -1,8 +1,8 @@
-﻿import { ISeasonInfo } from "../Models/ISeasonInfo";
-import { IHymnContent, IVariationInfo } from "../Models/IVariationInfo";
-import { IFormatInfo } from "../Models/IFormatInfo";
+﻿import { IFormatInfo } from "../Models/IFormatInfo";
 import { IHymnInfo } from "../Models/IHymnInfo";
+import { ISeasonInfo } from "../Models/ISeasonInfo";
 import { IServiceInfo } from "../Models/IServiceInfo";
+import { IHymnContent, IVariationInfo } from "../Models/IVariationInfo";
 
 /**
  * Data Provider Interface
@@ -22,4 +22,6 @@ export interface IDataProvider {
 
     getServiceHymnsFormatVariationList<T extends IHymnContent>(seasonId: string, serviceId: string, hymnId: string, formatId: string): Promise<IVariationInfo<T>[]>;
     getServiceHymnsFormatVariation<T extends IHymnContent>(seasonId: string, serviceId: string, hymnId: string, formatId: string, contentId: string): Promise<IVariationInfo<T>>;
+
+    getCommonContent(commonId: string): Promise<string>;
 }

--- a/src/DataProviders/SqlDataProvider/HazzatDbSchema.ts
+++ b/src/DataProviders/SqlDataProvider/HazzatDbSchema.ts
@@ -48,11 +48,31 @@ export namespace HazzatDbSchema {
         Content_English: string;
         Season_ID: number;
         Season_Name: string;
+        Reason_ID: number;
         Service_ID: number;
         Service_Name: string;
         ServiceHymn_ID: number;
         ServiceHymn_Title: string;
         Format_ID: number;
         Format_Name: string;
+    }
+
+    export interface ICommonContent {
+        ItemId: number;
+        Name: string;
+        Content: string;
+        Language: string;
+        Format_ID: number;
+    }
+
+    export interface IReason {
+        ItemId: number;
+        Name: string;
+        Long_English: string;
+        Long_Coptic: string;
+        Long_Arabic: string;
+        Short_English: string;
+        Short_Coptic: string;
+        Short_Arabic: string;
     }
 }

--- a/src/DataProviders/SqlDataProvider/Scripts/00.00.05.Install.sql
+++ b/src/DataProviders/SqlDataProvider/Scripts/00.00.05.Install.sql
@@ -1,0 +1,195 @@
+/****** Object:  StoredProcedure [dbo].[Hymns_CommonSelect]    Script Date: 10/11/2020 7:33:50 PM ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+CREATE PROCEDURE [dbo].[Hymns_CommonSelect]
+    @Common_ID int
+AS 
+BEGIN 
+    SELECT
+		[ID] AS ItemId,
+		[Name],
+		[Content],
+		[Language],
+		[Format_ID]
+    FROM [dbo].[Hymns_Common]
+    WHERE [ID] = @Common_ID
+END 
+
+GO
+
+/****** Object:  StoredProcedure [dbo].[Hymns_ReasonSelect]    Script Date: 10/11/2020 9:23:39 PM ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+CREATE PROCEDURE [dbo].[Hymns_ReasonSelect]
+    @Reason_ID int 
+AS 
+BEGIN 
+    SELECT
+        ID AS ItemId,
+        Name,
+        Long_English,
+        Long_Coptic,
+        Long_Arabic,
+        Short_English,
+        Short_Coptic,
+        Short_Arabic
+    FROM Hymns_Reasons
+    WHERE [ID] = @Reason_ID
+END 
+
+GO
+
+
+/****** Object:  StoredProcedure [dbo].[Hymns_HymnContentListSelectBySeasonIdAndServiceIdAndServiceHymnIdAndFormatId]    Script Date: 10/11/2020 10:12:53 PM ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+ALTER PROCEDURE [dbo].[Hymns_HymnContentListSelectBySeasonIdAndServiceIdAndServiceHymnIdAndFormatId]
+    @Season_ID int,
+	@Service_ID int,
+	@ServiceHymn_ID int,
+	@Format_ID int
+
+AS 
+BEGIN 
+    SELECT
+	    Hymns_ServiceHymnsContent.ID as ItemId,
+		Hymns_ServiceHymnsContent.Title as Content_Name,
+	    Hymns_Structure.Season_ID AS Season_ID,
+		Hymns_Seasons.Name AS Season_Name,
+		Hymns_Seasons.Reason_ID AS Reason_ID,
+		Hymns_Structure.Service_ID AS Service_ID,
+		Hymns_Services.Name AS Service_Name,
+		Hymns_ServiceHymns.ID AS ServiceHymn_ID,
+        Hymns_ServiceHymns.Title AS ServiceHymn_Title,
+		Hymns_Formats.ID AS Format_ID,
+		Hymns_Formats.Name AS Format_Name,
+	CASE
+		WHEN @Format_ID = 1 THEN Hymns_Text.Text_Arabic
+		WHEN @Format_ID = 2 THEN Hymns_Hazzat.Hazzat_Arabic
+		WHEN @Format_ID = 3 THEN Hymns_VerticalHazzat.VerticalHazzat_Arabic
+		WHEN @Format_ID = 6 THEN Hymns_Video.Video_Arabic
+		WHEN @Format_ID = 7 THEN Hymns_Information.Information_Arabic
+	END as Content_Arabic,
+	CASE
+		WHEN @Format_ID = 1 THEN Hymns_Text.Text_Coptic
+		WHEN @Format_ID = 2 THEN Hymns_Hazzat.Hazzat_Coptic
+		WHEN @Format_ID = 3 THEN Hymns_VerticalHazzat.VerticalHazzat_Coptic
+		WHEN @Format_ID = 6 THEN Hymns_Video.Video_Coptic
+		WHEN @Format_ID = 7 THEN NULL
+	END as Content_Coptic,
+	CASE
+		WHEN @Format_ID = 1 THEN Hymns_Text.Text_English
+		WHEN @Format_ID = 2 THEN Hymns_Hazzat.Hazzat_English
+		WHEN @Format_ID = 3 THEN Hymns_VerticalHazzat.VerticalHazzat_English
+		WHEN @Format_ID = 6 THEN Hymns_Video.Video_English
+		WHEN @Format_ID = 7 THEN Hymns_Information.Information_English
+	END as Content_English
+    FROM
+        Hymns_Structure
+		INNER JOIN Hymns_ServiceHymns ON Hymns_Structure.ID = Hymns_ServiceHymns.Structure_ID
+		INNER JOIN Hymns_ServiceHymnsContent ON Hymns_ServiceHymns.ID = Hymns_ServiceHymnsContent.ServiceHymn_ID
+		INNER JOIN Hymns_Formats ON Hymns_ServiceHymnsContent.Format_ID = Hymns_Formats.ID
+		INNER JOIN Hymns_Seasons ON Hymns_Structure.Season_ID = Hymns_Seasons.ID
+		INNER JOIN Hymns_Services on Hymns_Structure.Service_ID = Hymns_Services.ID
+		LEFT JOIN Hymns_Text ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Text.ID
+		LEFT JOIN Hymns_Hazzat ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Hazzat.ID
+		LEFT JOIN Hymns_VerticalHazzat ON Hymns_ServiceHymnsContent.Content_ID = Hymns_VerticalHazzat.ID
+		LEFT JOIN Hymns_Video ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Video.ID
+		LEFT JOIN Hymns_Information ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Information.ID
+    Where
+        Hymns_Structure.Season_ID = @Season_ID AND
+		Hymns_Structure.Service_ID = @Service_ID AND
+		Hymns_ServiceHymns.ID = @ServiceHymn_ID AND
+		Hymns_Formats.ID = @Format_ID
+	ORDER BY
+        ItemId
+END
+GO
+
+/****** Object:  StoredProcedure [dbo].[Hymns_HymnContentSelectBySeasonIdAndServiceIdAndServiceHymnIdAndFormatId]    Script Date: 10/11/2020 10:22:57 PM ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+ALTER PROCEDURE [dbo].[Hymns_HymnContentSelectBySeasonIdAndServiceIdAndServiceHymnIdAndFormatId]
+    @Season_ID int,
+	@Service_ID int,
+	@ServiceHymn_ID int,
+	@Format_ID int,
+	@Content_ID int
+
+AS 
+BEGIN 
+    SELECT
+	    Hymns_ServiceHymnsContent.ID as ItemId,
+		Hymns_ServiceHymnsContent.Title as Content_Name,
+	    Hymns_Structure.Season_ID AS Season_ID,
+		Hymns_Seasons.Name AS Season_Name,
+		Hymns_Seasons.Reason_ID AS Reason_ID,
+		Hymns_Structure.Service_ID AS Service_ID,
+		Hymns_Services.Name AS Service_Name,
+		Hymns_ServiceHymns.ID AS ServiceHymn_ID,
+        Hymns_ServiceHymns.Title AS ServiceHymn_Title,
+		Hymns_Formats.ID AS Format_ID,
+		Hymns_Formats.Name AS Format_Name,
+	CASE
+		WHEN @Format_ID = 1 THEN Hymns_Text.Text_Arabic
+		WHEN @Format_ID = 2 THEN Hymns_Hazzat.Hazzat_Arabic
+		WHEN @Format_ID = 3 THEN Hymns_VerticalHazzat.VerticalHazzat_Arabic
+		WHEN @Format_ID = 6 THEN Hymns_Video.Video_Arabic
+		WHEN @Format_ID = 7 THEN Hymns_Information.Information_Arabic
+	END as Content_Arabic,
+	CASE
+		WHEN @Format_ID = 1 THEN Hymns_Text.Text_Coptic
+		WHEN @Format_ID = 2 THEN Hymns_Hazzat.Hazzat_Coptic
+		WHEN @Format_ID = 3 THEN Hymns_VerticalHazzat.VerticalHazzat_Coptic
+		WHEN @Format_ID = 6 THEN Hymns_Video.Video_Coptic
+		WHEN @Format_ID = 7 THEN NULL
+	END as Content_Coptic,
+	CASE
+		WHEN @Format_ID = 1 THEN Hymns_Text.Text_English
+		WHEN @Format_ID = 2 THEN Hymns_Hazzat.Hazzat_English
+		WHEN @Format_ID = 3 THEN Hymns_VerticalHazzat.VerticalHazzat_English
+		WHEN @Format_ID = 6 THEN Hymns_Video.Video_English
+		WHEN @Format_ID = 7 THEN Hymns_Information.Information_English
+	END as Content_English
+    FROM
+        Hymns_Structure
+		INNER JOIN Hymns_ServiceHymns ON Hymns_Structure.ID = Hymns_ServiceHymns.Structure_ID
+		INNER JOIN Hymns_ServiceHymnsContent ON Hymns_ServiceHymns.ID = Hymns_ServiceHymnsContent.ServiceHymn_ID
+		INNER JOIN Hymns_Formats ON Hymns_ServiceHymnsContent.Format_ID = Hymns_Formats.ID
+		INNER JOIN Hymns_Seasons ON Hymns_Structure.Season_ID = Hymns_Seasons.ID
+		INNER JOIN Hymns_Services on Hymns_Structure.Service_ID = Hymns_Services.ID
+		LEFT JOIN Hymns_Text ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Text.ID
+		LEFT JOIN Hymns_Hazzat ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Hazzat.ID
+		LEFT JOIN Hymns_VerticalHazzat ON Hymns_ServiceHymnsContent.Content_ID = Hymns_VerticalHazzat.ID
+		LEFT JOIN Hymns_Video ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Video.ID
+		LEFT JOIN Hymns_Information ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Information.ID
+    Where
+        Hymns_Structure.Season_ID = @Season_ID AND
+		Hymns_Structure.Service_ID = @Service_ID AND
+		Hymns_ServiceHymns.ID = @ServiceHymn_ID AND
+		Hymns_Formats.ID = @Format_ID AND
+		Hymns_ServiceHymnsContent.ID = @Content_ID
+	ORDER BY
+        ItemId
+END
+GO

--- a/src/DataProviders/SqlDataProvider/Scripts/00.00.05.Uninstall.sql
+++ b/src/DataProviders/SqlDataProvider/Scripts/00.00.05.Uninstall.sql
@@ -1,0 +1,151 @@
+/****** Object:  StoredProcedure [dbo].[Hymns_CommonSelect]    Script Date: 10/11/2020 7:35:08 PM ******/
+DROP PROCEDURE [dbo].[Hymns_CommonSelect]
+GO
+
+/****** Object:  StoredProcedure [dbo].[Hymns_ReasonSelect]    Script Date: 10/11/2020 9:24:09 PM ******/
+DROP PROCEDURE [dbo].[Hymns_ReasonSelect]
+GO
+
+/****** Object:  StoredProcedure [dbo].[Hymns_HymnContentListSelectBySeasonIdAndServiceIdAndServiceHymnIdAndFormatId]    Script Date: 10/11/2020 10:12:53 PM ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+ALTER PROCEDURE [dbo].[Hymns_HymnContentListSelectBySeasonIdAndServiceIdAndServiceHymnIdAndFormatId]
+    @Season_ID int,
+	@Service_ID int,
+	@ServiceHymn_ID int,
+	@Format_ID int
+
+AS 
+BEGIN 
+    SELECT
+	    Hymns_ServiceHymnsContent.ID as ItemId,
+		Hymns_ServiceHymnsContent.Title as Content_Name,
+	    Hymns_Structure.Season_ID AS Season_ID,
+		Hymns_Seasons.Name AS Season_Name,
+		Hymns_Structure.Service_ID AS Service_ID,
+		Hymns_Services.Name AS Service_Name,
+		Hymns_ServiceHymns.ID AS ServiceHymn_ID,
+        Hymns_ServiceHymns.Title AS ServiceHymn_Title,
+		Hymns_Formats.ID AS Format_ID,
+		Hymns_Formats.Name AS Format_Name,
+	CASE
+		WHEN @Format_ID = 1 THEN Hymns_Text.Text_Arabic
+		WHEN @Format_ID = 2 THEN Hymns_Hazzat.Hazzat_Arabic
+		WHEN @Format_ID = 3 THEN Hymns_VerticalHazzat.VerticalHazzat_Arabic
+		WHEN @Format_ID = 6 THEN Hymns_Video.Video_Arabic
+		WHEN @Format_ID = 7 THEN Hymns_Information.Information_Arabic
+	END as Content_Arabic,
+	CASE
+		WHEN @Format_ID = 1 THEN Hymns_Text.Text_Coptic
+		WHEN @Format_ID = 2 THEN Hymns_Hazzat.Hazzat_Coptic
+		WHEN @Format_ID = 3 THEN Hymns_VerticalHazzat.VerticalHazzat_Coptic
+		WHEN @Format_ID = 6 THEN Hymns_Video.Video_Coptic
+		WHEN @Format_ID = 7 THEN NULL
+	END as Content_Coptic,
+	CASE
+		WHEN @Format_ID = 1 THEN Hymns_Text.Text_English
+		WHEN @Format_ID = 2 THEN Hymns_Hazzat.Hazzat_English
+		WHEN @Format_ID = 3 THEN Hymns_VerticalHazzat.VerticalHazzat_English
+		WHEN @Format_ID = 6 THEN Hymns_Video.Video_English
+		WHEN @Format_ID = 7 THEN Hymns_Information.Information_English
+	END as Content_English
+    FROM
+        Hymns_Structure
+		INNER JOIN Hymns_ServiceHymns ON Hymns_Structure.ID = Hymns_ServiceHymns.Structure_ID
+		INNER JOIN Hymns_ServiceHymnsContent ON Hymns_ServiceHymns.ID = Hymns_ServiceHymnsContent.ServiceHymn_ID
+		INNER JOIN Hymns_Formats ON Hymns_ServiceHymnsContent.Format_ID = Hymns_Formats.ID
+		INNER JOIN Hymns_Seasons ON Hymns_Structure.Season_ID = Hymns_Seasons.ID
+		INNER JOIN Hymns_Services on Hymns_Structure.Service_ID = Hymns_Services.ID
+		LEFT JOIN Hymns_Text ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Text.ID
+		LEFT JOIN Hymns_Hazzat ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Hazzat.ID
+		LEFT JOIN Hymns_VerticalHazzat ON Hymns_ServiceHymnsContent.Content_ID = Hymns_VerticalHazzat.ID
+		LEFT JOIN Hymns_Video ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Video.ID
+		LEFT JOIN Hymns_Information ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Information.ID
+    Where
+        Hymns_Structure.Season_ID = @Season_ID AND
+		Hymns_Structure.Service_ID = @Service_ID AND
+		Hymns_ServiceHymns.ID = @ServiceHymn_ID AND
+		Hymns_Formats.ID = @Format_ID
+	ORDER BY
+        ItemId
+END
+GO
+
+/****** Object:  StoredProcedure [dbo].[Hymns_HymnContentSelectBySeasonIdAndServiceIdAndServiceHymnIdAndFormatId]    Script Date: 10/11/2020 10:22:57 PM ******/
+SET ANSI_NULLS ON
+GO
+
+SET QUOTED_IDENTIFIER ON
+GO
+
+
+ALTER PROCEDURE [dbo].[Hymns_HymnContentSelectBySeasonIdAndServiceIdAndServiceHymnIdAndFormatId]
+    @Season_ID int,
+	@Service_ID int,
+	@ServiceHymn_ID int,
+	@Format_ID int,
+	@Content_ID int
+
+AS 
+BEGIN 
+    SELECT
+	    Hymns_ServiceHymnsContent.ID as ItemId,
+		Hymns_ServiceHymnsContent.Title as Content_Name,
+	    Hymns_Structure.Season_ID AS Season_ID,
+		Hymns_Seasons.Name AS Season_Name,
+		Hymns_Structure.Service_ID AS Service_ID,
+		Hymns_Services.Name AS Service_Name,
+		Hymns_ServiceHymns.ID AS ServiceHymn_ID,
+        Hymns_ServiceHymns.Title AS ServiceHymn_Title,
+		Hymns_Formats.ID AS Format_ID,
+		Hymns_Formats.Name AS Format_Name,
+	CASE
+		WHEN @Format_ID = 1 THEN Hymns_Text.Text_Arabic
+		WHEN @Format_ID = 2 THEN Hymns_Hazzat.Hazzat_Arabic
+		WHEN @Format_ID = 3 THEN Hymns_VerticalHazzat.VerticalHazzat_Arabic
+		WHEN @Format_ID = 6 THEN Hymns_Video.Video_Arabic
+		WHEN @Format_ID = 7 THEN Hymns_Information.Information_Arabic
+	END as Content_Arabic,
+	CASE
+		WHEN @Format_ID = 1 THEN Hymns_Text.Text_Coptic
+		WHEN @Format_ID = 2 THEN Hymns_Hazzat.Hazzat_Coptic
+		WHEN @Format_ID = 3 THEN Hymns_VerticalHazzat.VerticalHazzat_Coptic
+		WHEN @Format_ID = 6 THEN Hymns_Video.Video_Coptic
+		WHEN @Format_ID = 7 THEN NULL
+	END as Content_Coptic,
+	CASE
+		WHEN @Format_ID = 1 THEN Hymns_Text.Text_English
+		WHEN @Format_ID = 2 THEN Hymns_Hazzat.Hazzat_English
+		WHEN @Format_ID = 3 THEN Hymns_VerticalHazzat.VerticalHazzat_English
+		WHEN @Format_ID = 6 THEN Hymns_Video.Video_English
+		WHEN @Format_ID = 7 THEN Hymns_Information.Information_English
+	END as Content_English
+    FROM
+        Hymns_Structure
+		INNER JOIN Hymns_ServiceHymns ON Hymns_Structure.ID = Hymns_ServiceHymns.Structure_ID
+		INNER JOIN Hymns_ServiceHymnsContent ON Hymns_ServiceHymns.ID = Hymns_ServiceHymnsContent.ServiceHymn_ID
+		INNER JOIN Hymns_Formats ON Hymns_ServiceHymnsContent.Format_ID = Hymns_Formats.ID
+		INNER JOIN Hymns_Seasons ON Hymns_Structure.Season_ID = Hymns_Seasons.ID
+		INNER JOIN Hymns_Services on Hymns_Structure.Service_ID = Hymns_Services.ID
+		LEFT JOIN Hymns_Text ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Text.ID
+		LEFT JOIN Hymns_Hazzat ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Hazzat.ID
+		LEFT JOIN Hymns_VerticalHazzat ON Hymns_ServiceHymnsContent.Content_ID = Hymns_VerticalHazzat.ID
+		LEFT JOIN Hymns_Video ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Video.ID
+		LEFT JOIN Hymns_Information ON Hymns_ServiceHymnsContent.Content_ID = Hymns_Information.ID
+    Where
+        Hymns_Structure.Season_ID = @Season_ID AND
+		Hymns_Structure.Service_ID = @Service_ID AND
+		Hymns_ServiceHymns.ID = @ServiceHymn_ID AND
+		Hymns_Formats.ID = @Format_ID AND
+		Hymns_ServiceHymnsContent.ID = @Content_ID
+	ORDER BY
+        ItemId
+END
+GO
+
+

--- a/src/DataProviders/SqlDataProvider/SqlConstants.ts
+++ b/src/DataProviders/SqlDataProvider/SqlConstants.ts
@@ -10,6 +10,8 @@ export namespace Constants {
         export const HymnFormatSelectBySeasonIdAndServiceIdAndServiceHymnIdAndFormatId = "HymnFormatSelectBySeasonIdAndServiceIdAndServiceHymnIdAndFormatId";
         export const HymnContentListSelectBySeasonIdAndServiceIdAndServiceHymnIdAndFormatId = "HymnContentListSelectBySeasonIdAndServiceIdAndServiceHymnIdAndFormatId";
         export const HymnContentSelectBySeasonIdAndServiceIdAndServiceHymnIdAndFormatId = "HymnContentSelectBySeasonIdAndServiceIdAndServiceHymnIdAndFormatId";
+        export const CommonSelect = "CommonSelect";
+        export const ReasonSelect = "ReasonSelect";
 
         export const ServiceHymnListSelectBySeasonServiceId = "ServiceHymnListSelectBySeasonServiceId";
     }
@@ -20,5 +22,7 @@ export namespace Constants {
         export const ServiceHymnId = "ServiceHymn_ID";
         export const FormatId = "Format_ID";
         export const ContentId = "Content_ID";
+        export const CommonId = "Common_ID";
+        export const ReasonId = "Reason_ID";
     }
 }

--- a/src/DataProviders/SqlDataProvider/SqlDataProvider.ts
+++ b/src/DataProviders/SqlDataProvider/SqlDataProvider.ts
@@ -187,7 +187,7 @@ export class SqlDataProvider implements IDataProvider {
 
         let result = content;
         const longReasonRegEx = new RegExp("\<reason_long\>", "i");
-        const shortReasonRegEx = new RegExp("\<short_long\>", "i");
+        const shortReasonRegEx = new RegExp("\<reason_short\>", "i");
 
         const longReasonMatch = result.match(longReasonRegEx);
         const shortReasonMatch = result.match(shortReasonRegEx);

--- a/src/DataProviders/SqlDataProvider/SqlDataProvider.ts
+++ b/src/DataProviders/SqlDataProvider/SqlDataProvider.ts
@@ -2,26 +2,27 @@ import { inject, injectable } from "inversify";
 import * as Sql from "mssql";
 import { IConfiguration } from "../../Common/Configuration";
 import { ErrorCodes, HazzatApplicationError } from "../../Common/Errors";
+import { Language } from "../../Common/Types/Language";
 import { Log } from "../../Common/Utils/Logger";
 import { SqlHelpers } from "../../Common/Utils/SqlHelpers";
-import { ISeasonInfo } from "../../Models/ISeasonInfo";
-import { IHazzatContent, IHymnContent, IInformationContent, IVariationInfo, ITextContent, IVerticalHazzatContent, IVideoContent, ContentType } from "../../Models/IVariationInfo";
 import { IFormatInfo } from "../../Models/IFormatInfo";
 import { IHymnInfo } from "../../Models/IHymnInfo";
+import { ISeasonInfo } from "../../Models/ISeasonInfo";
 import { IServiceInfo } from "../../Models/IServiceInfo";
+import { ContentType, IHazzatContent, IHymnContent, IInformationContent, ITextContent, IVariationInfo, IVerticalHazzatContent, IVideoContent } from "../../Models/IVariationInfo";
+import { ResourceTypes } from "../../Routes/ResourceTypes";
 import { TYPES } from "../../types";
 import { IDataProvider } from "../IDataProvider";
 import { HazzatDbSchema } from "./HazzatDbSchema";
 import { Constants } from "./SqlConstants";
 import ConnectionPool = Sql.ConnectionPool;
-import { ResourceTypes } from "../../Routes/ResourceTypes";
 
 /*
  * Sql Data Provider
  */
 @injectable()
 export class SqlDataProvider implements IDataProvider {
-    private static convertSeasonDbItemToSeasonInfo(seasonDbItem: HazzatDbSchema.ISeason): ISeasonInfo {
+    private static _convertSeasonDbItemToSeasonInfo(seasonDbItem: HazzatDbSchema.ISeason): ISeasonInfo {
         return {
             id: `/${ResourceTypes.Seasons}/${seasonDbItem.ItemId}`,
             isDateSpecific: seasonDbItem.Date_Specific,
@@ -31,7 +32,7 @@ export class SqlDataProvider implements IDataProvider {
         };
     }
 
-    private static convertServiceDbItemToServiceInfo(serviceDbItem: HazzatDbSchema.IService): IServiceInfo {
+    private static _convertServiceDbItemToServiceInfo(serviceDbItem: HazzatDbSchema.IService): IServiceInfo {
         return {
             id: `/${ResourceTypes.Seasons}/${serviceDbItem.Season_ID}/${ResourceTypes.Services}/${serviceDbItem.ItemId}`,
             name: serviceDbItem.Service_Name,
@@ -39,7 +40,7 @@ export class SqlDataProvider implements IDataProvider {
         };
     }
 
-    private static convertServiceHymnDbItemToHymnInfo(
+    private static _convertServiceHymnDbItemToHymnInfo(
         serviceHymnDbItem: HazzatDbSchema.IServiceHymn
     ): IHymnInfo {
         return {
@@ -49,7 +50,7 @@ export class SqlDataProvider implements IDataProvider {
         };
     }
 
-    public static convertServiceHymnFormatDbItemToFormatInfo(
+    private static _convertServiceHymnFormatDbItemToFormatInfo(
         serviceHymnFormatDbItem: HazzatDbSchema.IServiceHymnFormat
     ): IFormatInfo {
         return {
@@ -60,19 +61,27 @@ export class SqlDataProvider implements IDataProvider {
         };
     }
 
-    public static convertServiceHymnFormatContentDbItemToServiceHymnFormatContentInfo<T extends IHymnContent>(
-        serviceHymnFormatContentDbItem: HazzatDbSchema.IServiceHymnFormatContent,
-        formatId: number
-    ): IVariationInfo<T> {
+    private async _convertServiceHymnFormatContentDbItemToServiceHymnFormatContentInfo<T extends IHymnContent>(
+        serviceHymnFormatContentDbItem: HazzatDbSchema.IServiceHymnFormatContent
+    ): Promise<IVariationInfo<T>> {
 
         let content: any = null;
 
-        switch (formatId) {
+        switch (serviceHymnFormatContentDbItem.Format_ID) {
             case 1: // Text
                 content = {
-                    arabicText: serviceHymnFormatContentDbItem.Content_Arabic,
-                    copticText: serviceHymnFormatContentDbItem.Content_Coptic,
-                    englishText: serviceHymnFormatContentDbItem.Content_English,
+                    arabicText: await this._prepareTextContent(
+                        serviceHymnFormatContentDbItem.Content_Arabic,
+                        serviceHymnFormatContentDbItem.Reason_ID,
+                        Language.Arabic),
+                    copticText: await this._prepareTextContent(
+                        serviceHymnFormatContentDbItem.Content_Coptic,
+                        serviceHymnFormatContentDbItem.Reason_ID,
+                        Language.Coptic),
+                    englishText: await this._prepareTextContent(
+                        serviceHymnFormatContentDbItem.Content_English,
+                        serviceHymnFormatContentDbItem.Reason_ID,
+                        Language.English),
                     contentType: ContentType.TextContent
                 } as ITextContent;
                 break;
@@ -111,13 +120,93 @@ export class SqlDataProvider implements IDataProvider {
                 throw new HazzatApplicationError(
                     ErrorCodes[ErrorCodes.NotSupportedError],
                     `The format '${serviceHymnFormatContentDbItem.Format_Name}' is not currently supported.`,
-                    `format id: '${formatId}'`);
+                    `format id: '${serviceHymnFormatContentDbItem.Format_ID}'`);
         }
         return {
             id: `/${ResourceTypes.Seasons}/${serviceHymnFormatContentDbItem.Season_ID}/${ResourceTypes.Services}/${serviceHymnFormatContentDbItem.Service_ID}/${ResourceTypes.Hymns}/${serviceHymnFormatContentDbItem.ServiceHymn_ID}/${ResourceTypes.Formats}/${serviceHymnFormatContentDbItem.Format_ID}/${ResourceTypes.Variations}/${serviceHymnFormatContentDbItem.ItemId}`,
             name: serviceHymnFormatContentDbItem.Content_Name,
             content
         };
+    }
+
+    /**
+     * Prepares the content as stored in storage and makes it ready to presented
+     * to callers through API
+     * @param content The text content as it was stored
+     */
+    private async _prepareTextContent(content: string, reasonId: number, language: Language): Promise<string> {
+        let result = content;
+
+        // Replace references to common content
+        result = await this._replaceCommonContent(result);
+
+        // Replace the reason for the season
+        result = await this._replaceReason(result, reasonId, language);
+
+        return result;
+    }
+
+    private async _replaceCommonContent(content: string): Promise<string> {
+        let result = content;
+        const commonContentRegEx = new RegExp("\<common\=([0-9]+)\>", "i");
+        let matchGroups = result.match(commonContentRegEx);
+
+        // Keep replacing common as long as there are additional references
+        while (!!matchGroups) {
+            const matchedString = matchGroups[0];
+            const commonId = matchGroups[1];
+
+            const commonContent = await this.getCommonContent(commonId);
+
+            result = result.replace(matchedString, commonContent);
+            matchGroups = result.match(commonContentRegEx);
+        }
+
+        return result;
+    }
+
+    private async _replaceReason(content: string, reasonId: number, language: Language): Promise<string> {
+        let result = content;
+        const longReasonRegEx = new RegExp("\<reason_long\>", "i");
+        const shortReasonRegEx = new RegExp("\<short_long\>", "i");
+
+        const longReasonMatch = result.match(longReasonRegEx);
+        const shortReasonMatch = result.match(shortReasonRegEx);
+
+        // only call the DB if there's a match
+        if (!longReasonMatch && !shortReasonMatch) {
+            return result;
+        }
+
+        const reasonInfo = await this._getReason(reasonId);
+        let longReason: string;
+        let shortReason: string;
+
+        switch (language) {
+            case Language.English:
+                longReason = reasonInfo.Long_English;
+                shortReason = reasonInfo.Short_English;
+                break;
+            case Language.Coptic:
+                longReason = reasonInfo.Long_Coptic;
+                shortReason = reasonInfo.Short_Coptic;
+                break;
+            case Language.Arabic:
+                longReason = reasonInfo.Long_Arabic;
+                shortReason = reasonInfo.Short_Arabic;
+                break;
+            default:
+        }
+
+        if (!!longReasonMatch) {
+            result = result.replace(longReasonMatch[0], longReason);
+        }
+
+        if (!!shortReasonMatch) {
+            result = result.replace(shortReasonMatch[0], shortReason);
+        }
+
+        return result;
     }
 
     private connectionPool: ConnectionPool;
@@ -159,7 +248,7 @@ export class SqlDataProvider implements IDataProvider {
             }
 
             const seasons: ISeasonInfo[] = result.recordsets[0]
-                .map((row) => SqlDataProvider.convertSeasonDbItemToSeasonInfo(row));
+                .map((row) => SqlDataProvider._convertSeasonDbItemToSeasonInfo(row));
             return seasons;
         });
     }
@@ -188,7 +277,7 @@ export class SqlDataProvider implements IDataProvider {
                     ErrorCodes[ErrorCodes.NotFoundError],
                     `Unable to find season with id '${seasonId}'`);
             }
-            return SqlDataProvider.convertSeasonDbItemToSeasonInfo(row);
+            return SqlDataProvider._convertSeasonDbItemToSeasonInfo(row);
         });
     }
 
@@ -211,7 +300,7 @@ export class SqlDataProvider implements IDataProvider {
             }
 
             const services: IServiceInfo[] = result.recordsets[0]
-                .map((row) => SqlDataProvider.convertServiceDbItemToServiceInfo(row));
+                .map((row) => SqlDataProvider._convertServiceDbItemToServiceInfo(row));
             return services;
 
         });
@@ -248,7 +337,7 @@ export class SqlDataProvider implements IDataProvider {
                     ErrorCodes[ErrorCodes.NotFoundError],
                     `Unable to find service with season id '${seasonId}' and Service id '${serviceId}`);
             }
-            return SqlDataProvider.convertServiceDbItemToServiceInfo(row);
+            return SqlDataProvider._convertServiceDbItemToServiceInfo(row);
         });
     }
 
@@ -279,7 +368,7 @@ export class SqlDataProvider implements IDataProvider {
             }
 
             const serviceHymns: IHymnInfo[] = result.recordsets[0]
-                .map((row) => SqlDataProvider.convertServiceHymnDbItemToHymnInfo(row));
+                .map((row) => SqlDataProvider._convertServiceHymnDbItemToHymnInfo(row));
             return serviceHymns;
         });
     }
@@ -322,7 +411,7 @@ export class SqlDataProvider implements IDataProvider {
                     ErrorCodes[ErrorCodes.NotFoundError],
                     `Unable to find hymn with season id '${seasonId}', service id '${serviceId}, and hymn id '${hymnId}'`);
             }
-            return SqlDataProvider.convertServiceHymnDbItemToHymnInfo(row);
+            return SqlDataProvider._convertServiceHymnDbItemToHymnInfo(row);
         });
     }
 
@@ -360,7 +449,7 @@ export class SqlDataProvider implements IDataProvider {
             }
 
             const serviceHymns: IFormatInfo[] = result.recordsets[0]
-                .map((row) => SqlDataProvider.convertServiceHymnFormatDbItemToFormatInfo(row));
+                .map((row) => SqlDataProvider._convertServiceHymnFormatDbItemToFormatInfo(row));
             return serviceHymns;
         });
     }
@@ -410,12 +499,12 @@ export class SqlDataProvider implements IDataProvider {
                     ErrorCodes[ErrorCodes.NotFoundError],
                     `Unable to find hymn formats with season id '${seasonId}', service id '${serviceId}, hymn id '${hymnId}', and format id '${formatId}'`);
             }
-            return SqlDataProvider.convertServiceHymnFormatDbItemToFormatInfo(row);
+            return SqlDataProvider._convertServiceHymnFormatDbItemToFormatInfo(row);
         });
     }
 
     public getServiceHymnsFormatVariationList<T extends IHymnContent>(seasonId: string, serviceId: string, hymnId: string, formatId: string): Promise<IVariationInfo<T>[]> {
-        return this._connectAndExecute<IVariationInfo<T>[]>(async (cp: ConnectionPool) => {
+        return this._connectAndExecute<IVariationInfo<any>[]>(async (cp: ConnectionPool) => {
             if (!SqlHelpers.isValidPositiveIntParameter(seasonId)) {
                 throw new HazzatApplicationError(
                     ErrorCodes[ErrorCodes.InvalidParameterError],
@@ -454,8 +543,9 @@ export class SqlDataProvider implements IDataProvider {
                     "Unexpected database error");
             }
 
-            const serviceHymns: IVariationInfo<T>[] = result.recordsets[0]
-                .map((row) => SqlDataProvider.convertServiceHymnFormatContentDbItemToServiceHymnFormatContentInfo(row, +formatId));
+            const serviceHymns: IVariationInfo<IHymnContent>[] = await Promise.all(result.recordsets[0]
+                .map((row) => this._convertServiceHymnFormatContentDbItemToServiceHymnFormatContentInfo(row)));
+
             return serviceHymns;
         });
     }
@@ -513,7 +603,61 @@ export class SqlDataProvider implements IDataProvider {
                     ErrorCodes[ErrorCodes.NotFoundError],
                     `Unable to find hymn variation with season id '${seasonId}', service id '${serviceId}, hymn id '${hymnId}', format id '${formatId}', and variation id '${variationId}'`);
             }
-            return SqlDataProvider.convertServiceHymnFormatContentDbItemToServiceHymnFormatContentInfo(row, +formatId);
+            return this._convertServiceHymnFormatContentDbItemToServiceHymnFormatContentInfo(row);
+        });
+    }
+
+    public getCommonContent(commonId: string): Promise<string> {
+        return this._connectAndExecute<string>(async (cp: ConnectionPool) => {
+            if (!SqlHelpers.isValidPositiveIntParameter(commonId)) {
+                throw new HazzatApplicationError(
+                    ErrorCodes[ErrorCodes.InvalidParameterError],
+                    "Invalid common id specified.",
+                    `Common id: '${commonId}'`);
+            }
+
+            const result = await cp.request()
+                .input(Constants.Parameters.CommonId, Sql.Int, commonId)
+                .execute(this._getQualifiedName(Constants.StoredProcedures.CommonSelect));
+
+            if (!SqlHelpers.isValidResult(result)) {
+                throw new HazzatApplicationError(
+                    ErrorCodes[ErrorCodes.DatabaseError],
+                    "Unexpected database error");
+            }
+
+            const row = result.recordsets[0][0];
+            if (!row) {
+                throw new HazzatApplicationError(
+                    ErrorCodes[ErrorCodes.NotFoundError],
+                    `Unable to get common hymn content common id '${commonId}'`);
+            }
+
+            const contentResult: HazzatDbSchema.ICommonContent = row;
+            return contentResult.Content;
+        });
+    }
+
+    private _getReason(reasonId: number): Promise<HazzatDbSchema.IReason> {
+        return this._connectAndExecute<HazzatDbSchema.IReason>(async (cp: ConnectionPool) => {
+            const result = await cp.request()
+                .input(Constants.Parameters.ReasonId, Sql.Int, reasonId)
+                .execute(this._getQualifiedName(Constants.StoredProcedures.ReasonSelect));
+
+            if (!SqlHelpers.isValidResult(result)) {
+                throw new HazzatApplicationError(
+                    ErrorCodes[ErrorCodes.DatabaseError],
+                    "Unexpected database error");
+            }
+
+            const row = result.recordsets[0][0];
+            if (!row) {
+                throw new HazzatApplicationError(
+                    ErrorCodes[ErrorCodes.NotFoundError],
+                    `Unable to get reason with id '${reasonId}'`);
+            }
+
+            return row;
         });
     }
 

--- a/src/DataProviders/SqlDataProvider/SqlDataProvider.ts
+++ b/src/DataProviders/SqlDataProvider/SqlDataProvider.ts
@@ -96,17 +96,17 @@ export class SqlDataProvider implements IDataProvider {
                 break;
             case 2: // Hazzat
                 content = {
-                    arabicHazzat: serviceHymnFormatContentDbItem.Content_Arabic,
-                    copticHazzat: serviceHymnFormatContentDbItem.Content_Coptic,
-                    englishHazzat: serviceHymnFormatContentDbItem.Content_English,
+                    arabicHazzat: await this._prepareHazzatContent(serviceHymnFormatContentDbItem.Content_Arabic),
+                    copticHazzat: await this._prepareHazzatContent(serviceHymnFormatContentDbItem.Content_Coptic),
+                    englishHazzat: await this._prepareHazzatContent(serviceHymnFormatContentDbItem.Content_English),
                     contentType: ContentType.HazzatContent
                 } as IHazzatContent;
                 break;
             case 3: // Vertical Hazzat
                 content = {
-                    arabicVerticalHazzat: serviceHymnFormatContentDbItem.Content_Arabic,
-                    copticVerticalHazzat: serviceHymnFormatContentDbItem.Content_Coptic,
-                    englishVerticalHazzat: serviceHymnFormatContentDbItem.Content_English,
+                    arabicVerticalHazzat: await this._prepareHazzatContent(serviceHymnFormatContentDbItem.Content_Arabic),
+                    copticVerticalHazzat: await this._prepareHazzatContent(serviceHymnFormatContentDbItem.Content_Coptic),
+                    englishVerticalHazzat: await this._prepareHazzatContent(serviceHymnFormatContentDbItem.Content_English),
                     contentType: ContentType.VerticalHazzatContent
                 } as IVerticalHazzatContent;
                 break;
@@ -143,7 +143,7 @@ export class SqlDataProvider implements IDataProvider {
      * to callers through API
      * @param content The text content as it was stored
      * @param language The content language
-     * * @param getReasonFunc A method to get the reason info.
+     * @param getReasonFunc A method to get the reason info.
      */
     private async _prepareTextContent(content: string, language: Language, getReasonFunc: () => Promise<HazzatDbSchema.IReason>): Promise<string> {
         let result = content;
@@ -158,6 +158,10 @@ export class SqlDataProvider implements IDataProvider {
     }
 
     private async _replaceCommonContent(content: string): Promise<string> {
+        if (!content) {
+            return Promise.resolve(content);
+        }
+
         let result = content;
         const commonContentRegEx = new RegExp("\<common\=([0-9]+)\>", "i");
         let matchGroups = result.match(commonContentRegEx);
@@ -177,6 +181,10 @@ export class SqlDataProvider implements IDataProvider {
     }
 
     private async _replaceReason(content: string, language: Language, getReasonFunc: () => Promise<HazzatDbSchema.IReason>): Promise<string> {
+        if (!content) {
+            return Promise.resolve(content);
+        }
+
         let result = content;
         const longReasonRegEx = new RegExp("\<reason_long\>", "i");
         const shortReasonRegEx = new RegExp("\<short_long\>", "i");
@@ -216,6 +224,20 @@ export class SqlDataProvider implements IDataProvider {
         if (!!shortReasonMatch) {
             result = result.replace(shortReasonMatch[0], shortReason);
         }
+
+        return result;
+    }
+
+    /**
+     * Prepares the content as stored in storage and makes it ready to presented
+     * to callers through API
+     * @param content The hazzat content as it was stored
+     */
+    private async _prepareHazzatContent(content: string): Promise<string> {
+        let result = content;
+
+        // Replace references to common content
+        result = await this._replaceCommonContent(result);
 
         return result;
     }

--- a/src/hazzat-api.njsproj
+++ b/src/hazzat-api.njsproj
@@ -37,6 +37,7 @@
   <ItemGroup>
     <TypeScriptCompile Include="Common\HttpError.ts" />
     <TypeScriptCompile Include="Common\Errors.ts" />
+    <TypeScriptCompile Include="Common\Types\Language.ts" />
     <TypeScriptCompile Include="Common\Types\FormatType.ts" />
     <TypeScriptCompile Include="Common\Types\StringMap.ts" />
     <TypeScriptCompile Include="Common\Utils\Logger.ts" />
@@ -61,6 +62,8 @@
     <TypeScriptCompile Include="Routes\HomeController.ts" />
     <TypeScriptCompile Include="Routes\SeasonsController.ts" />
     <Content Include="Configs\prod.json" />
+    <Content Include="DataProviders\SqlDataProvider\Scripts\00.00.05.Uninstall.sql" />
+    <Content Include="DataProviders\SqlDataProvider\Scripts\00.00.05.Install.sql" />
     <Content Include="DataProviders\SqlDataProvider\Scripts\00.00.04.Uninstall.sql" />
     <Content Include="DataProviders\SqlDataProvider\Scripts\00.00.04.Install.sql" />
     <Content Include="DataProviders\SqlDataProvider\Scripts\00.00.03.Uninstall.sql" />

--- a/src/test/Helpers/Validators.ts
+++ b/src/test/Helpers/Validators.ts
@@ -110,4 +110,12 @@ export class Validators {
         contentBody.should.have.property("englishInformation");
         contentBody.should.have.property("contentType").eq(ContentType.InformationContent);
     }
+
+    public static validateDoesNotInclude(contentString: string, searchString: string): void {
+        if (!contentString) {
+            return;
+        }
+
+        contentString.should.not.contain(searchString);
+    }
 }

--- a/src/test/seasons.spec.ts
+++ b/src/test/seasons.spec.ts
@@ -543,8 +543,8 @@ describe("Seasons controller", () => {
         });
     });
 
-    describe("/GET all season service hymn format contents", () => {
-        it("should get a season service hymn format contents (text)", (done) => {
+    describe("/GET all season service hymn format variations", () => {
+        it("should get a season service hymn format variations (text)", (done) => {
             chai.request(server)
                 .get(`/${ResourceTypes.Seasons}/1/${ResourceTypes.Services}/15/${ResourceTypes.Hymns}/311/${ResourceTypes.Formats}/1/${ResourceTypes.Variations}`)
                 .end((err, res) => {
@@ -555,7 +555,66 @@ describe("Seasons controller", () => {
                 });
         });
 
-        it("should get a season service hymn format contents (hazzat)", (done) => {
+        it("should get a season service hymn format variations (text) with common content", (done) => {
+            chai.request(server)
+                .get(`/${ResourceTypes.Seasons}/33/${ResourceTypes.Services}/4/${ResourceTypes.Hymns}/460/${ResourceTypes.Formats}/1/${ResourceTypes.Variations}`)
+                .end((err, res) => {
+                    Validators.validateArrayResponse(res);
+                    Validators.validateServiceHymnFormatVariationResponse(res.body[0]);
+                    Validators.validateTextContentResponse(res.body[0].content);
+                    Validators.validateDoesNotInclude(res.body[0].content.arabicText, "<common=");
+                    Validators.validateDoesNotInclude(res.body[0].content.copticText, "<common=");
+                    Validators.validateDoesNotInclude(res.body[0].content.englishText, "<common=");
+                    done();
+                });
+        });
+
+        it("should get a season service hymn format variations (text) with short reason content", (done) => {
+            chai.request(server)
+                .get(`/${ResourceTypes.Seasons}/6/${ResourceTypes.Services}/3/${ResourceTypes.Hymns}/48/${ResourceTypes.Formats}/1/${ResourceTypes.Variations}`)
+                .end((err, res) => {
+                    Validators.validateArrayResponse(res);
+                    Validators.validateServiceHymnFormatVariationResponse(res.body[0]);
+                    Validators.validateTextContentResponse(res.body[0].content);
+                    Validators.validateDoesNotInclude(res.body[0].content.arabicText, "<reason_short>");
+                    Validators.validateDoesNotInclude(res.body[0].content.copticText, "<reason_short>");
+                    Validators.validateDoesNotInclude(res.body[0].content.englishText, "<reason_short>");
+                    done();
+                });
+        });
+
+        it("should get a season service hymn format variations (text) with long reason content", (done) => {
+            chai.request(server)
+                .get(`/${ResourceTypes.Seasons}/1/${ResourceTypes.Services}/2/${ResourceTypes.Hymns}/331/${ResourceTypes.Formats}/1/${ResourceTypes.Variations}`)
+                .end((err, res) => {
+                    Validators.validateArrayResponse(res);
+                    Validators.validateServiceHymnFormatVariationResponse(res.body[0]);
+                    Validators.validateTextContentResponse(res.body[0].content);
+                    Validators.validateDoesNotInclude(res.body[0].content.arabicText, "<reason_long>");
+                    Validators.validateDoesNotInclude(res.body[0].content.copticText, "<reason_long>");
+                    Validators.validateDoesNotInclude(res.body[0].content.englishText, "<reason_long>");
+                    done();
+                });
+        });
+
+        it("should get a season service hymn format variations (text) with reason & common content", (done) => {
+            chai.request(server)
+                .get(`/${ResourceTypes.Seasons}/33/${ResourceTypes.Services}/24/${ResourceTypes.Hymns}/456/${ResourceTypes.Formats}/1/${ResourceTypes.Variations}`)
+                .end((err, res) => {
+                    Validators.validateArrayResponse(res);
+                    Validators.validateServiceHymnFormatVariationResponse(res.body[0]);
+                    Validators.validateTextContentResponse(res.body[0].content);
+                    Validators.validateDoesNotInclude(res.body[0].content.arabicText, "<common=");
+                    Validators.validateDoesNotInclude(res.body[0].content.copticText, "<common=");
+                    Validators.validateDoesNotInclude(res.body[0].content.englishText, "<common=");
+                    Validators.validateDoesNotInclude(res.body[0].content.arabicText, "<reason_");
+                    Validators.validateDoesNotInclude(res.body[0].content.copticText, "<reason_");
+                    Validators.validateDoesNotInclude(res.body[0].content.englishText, "<reason_");
+                    done();
+                });
+        });
+
+        it("should get a season service hymn format variations (hazzat)", (done) => {
             chai.request(server)
                 .get(`/${ResourceTypes.Seasons}/1/${ResourceTypes.Services}/15/${ResourceTypes.Hymns}/311/${ResourceTypes.Formats}/2/${ResourceTypes.Variations}`)
                 .end((err, res) => {
@@ -566,7 +625,21 @@ describe("Seasons controller", () => {
                 });
         });
 
-        it("should get a season service hymn format contents (vertical hazzat)", (done) => {
+        it("should get a season service hymn format variations (hazzat) with common content", (done) => {
+            chai.request(server)
+                .get(`/${ResourceTypes.Seasons}/1/${ResourceTypes.Services}/21/${ResourceTypes.Hymns}/377/${ResourceTypes.Formats}/2/${ResourceTypes.Variations}`)
+                .end((err, res) => {
+                    Validators.validateArrayResponse(res);
+                    Validators.validateServiceHymnFormatVariationResponse(res.body[0]);
+                    Validators.validateHazzatContentResponse(res.body[0].content);
+                    Validators.validateDoesNotInclude(res.body[0].content.arabicHazzat, "<common=");
+                    Validators.validateDoesNotInclude(res.body[0].content.copticHazzat, "<common=");
+                    Validators.validateDoesNotInclude(res.body[0].content.englishHazzat, "<common=");
+                    done();
+                });
+        });
+
+        it("should get a season service hymn format variations (vertical hazzat)", (done) => {
             chai.request(server)
                 .get(`/${ResourceTypes.Seasons}/1/${ResourceTypes.Services}/2/${ResourceTypes.Hymns}/279/${ResourceTypes.Formats}/3/${ResourceTypes.Variations}`)
                 .end((err, res) => {
@@ -577,7 +650,21 @@ describe("Seasons controller", () => {
                 });
         });
 
-        it("should return a 501 for unsupported season service hymn format contents (Musical Notes)", (done) => {
+        it("should get a season service hymn format variations (vertical hazzat) with common content", (done) => {
+            chai.request(server)
+                .get(`/${ResourceTypes.Seasons}/1/${ResourceTypes.Services}/21/${ResourceTypes.Hymns}/377/${ResourceTypes.Formats}/3/${ResourceTypes.Variations}`)
+                .end((err, res) => {
+                    Validators.validateArrayResponse(res);
+                    Validators.validateServiceHymnFormatVariationResponse(res.body[0]);
+                    Validators.validateVerticalHazzatContentResponse(res.body[0].content);
+                    Validators.validateDoesNotInclude(res.body[0].content.arabicVerticalHazzat, "<common=");
+                    Validators.validateDoesNotInclude(res.body[0].content.copticVerticalHazzat, "<common=");
+                    Validators.validateDoesNotInclude(res.body[0].content.englishVerticalHazzat, "<common=");
+                    done();
+                });
+        });
+
+        it("should return a 501 for unsupported season service hymn format variations (Musical Notes)", (done) => {
             chai.request(server)
                 .get(`/${ResourceTypes.Seasons}/32/${ResourceTypes.Services}/17/${ResourceTypes.Hymns}/334/${ResourceTypes.Formats}/4/${ResourceTypes.Variations}`)
                 .end((err, res) => {
@@ -586,7 +673,7 @@ describe("Seasons controller", () => {
                 });
         });
 
-        it("should return a 501 for unsupported season service hymn format contents (Audio)", (done) => {
+        it("should return a 501 for unsupported season service hymn format variations (Audio)", (done) => {
             chai.request(server)
                 .get(`/${ResourceTypes.Seasons}/14/${ResourceTypes.Services}/4/${ResourceTypes.Hymns}/162/${ResourceTypes.Formats}/5/${ResourceTypes.Variations}`)
                 .end((err, res) => {
@@ -595,7 +682,7 @@ describe("Seasons controller", () => {
                 });
         });
 
-        it("should get a season service hymn format contents (video)", (done) => {
+        it("should get a season service hymn format variations (video)", (done) => {
             chai.request(server)
                 .get(`/${ResourceTypes.Seasons}/14/${ResourceTypes.Services}/4/${ResourceTypes.Hymns}/162/${ResourceTypes.Formats}/6/${ResourceTypes.Variations}`)
                 .end((err, res) => {
@@ -606,7 +693,7 @@ describe("Seasons controller", () => {
                 });
         });
 
-        it("should get a season service hymn format contents (information)", (done) => {
+        it("should get a season service hymn format variations (information)", (done) => {
             chai.request(server)
                 .get(`/${ResourceTypes.Seasons}/14/${ResourceTypes.Services}/4/${ResourceTypes.Hymns}/162/${ResourceTypes.Formats}/7/${ResourceTypes.Variations}`)
                 .end((err, res) => {
@@ -726,7 +813,7 @@ describe("Seasons controller", () => {
         });
     });
 
-    describe("/GET a season service hymn format content", () => {
+    describe("/GET a season service hymn format variation", () => {
         it("should get a season service hymn content (text)", (done) => {
             const resourceId = `/${ResourceTypes.Seasons}/1/${ResourceTypes.Services}/15/${ResourceTypes.Hymns}/311/${ResourceTypes.Formats}/1/${ResourceTypes.Variations}/288`;
             chai.request(server)
@@ -739,7 +826,70 @@ describe("Seasons controller", () => {
                 });
         });
 
-        it("should get a season service hymn content (hazzat)", (done) => {
+        it("should get a season service hymn content (text) with common content", (done) => {
+            const resourceId = `/${ResourceTypes.Seasons}/33/${ResourceTypes.Services}/4/${ResourceTypes.Hymns}/460/${ResourceTypes.Formats}/1/${ResourceTypes.Variations}/721`;
+            chai.request(server)
+                .get(resourceId)
+                .end((err, res) => {
+                    Validators.validateObjectResponse(res);
+                    Validators.validateServiceHymnFormatVariationResponse(res.body, resourceId);
+                    Validators.validateTextContentResponse(res.body.content);
+                    Validators.validateDoesNotInclude(res.body.content.arabicText, "<common=");
+                    Validators.validateDoesNotInclude(res.body.content.copticText, "<common=");
+                    Validators.validateDoesNotInclude(res.body.content.englishText, "<common=");
+                    done();
+                });
+        });
+
+        it("should get a season service hymn content (text) with short reason content", (done) => {
+            const resourceId = `/${ResourceTypes.Seasons}/6/${ResourceTypes.Services}/3/${ResourceTypes.Hymns}/48/${ResourceTypes.Formats}/1/${ResourceTypes.Variations}/37`;
+            chai.request(server)
+                .get(resourceId)
+                .end((err, res) => {
+                    Validators.validateObjectResponse(res);
+                    Validators.validateServiceHymnFormatVariationResponse(res.body, resourceId);
+                    Validators.validateTextContentResponse(res.body.content);
+                    Validators.validateDoesNotInclude(res.body.content.arabicText, "<reason_short>");
+                    Validators.validateDoesNotInclude(res.body.content.copticText, "<reason_short>");
+                    Validators.validateDoesNotInclude(res.body.content.englishText, "<reason_short>");
+                    done();
+                });
+        });
+
+        it("should get a season service hymn content (text) with long reason content", (done) => {
+            const resourceId = `/${ResourceTypes.Seasons}/1/${ResourceTypes.Services}/2/${ResourceTypes.Hymns}/331/${ResourceTypes.Formats}/1/${ResourceTypes.Variations}/302`;
+            chai.request(server)
+                .get(resourceId)
+                .end((err, res) => {
+                    Validators.validateObjectResponse(res);
+                    Validators.validateServiceHymnFormatVariationResponse(res.body, resourceId);
+                    Validators.validateTextContentResponse(res.body.content);
+                    Validators.validateDoesNotInclude(res.body.content.arabicText, "<reason_long>");
+                    Validators.validateDoesNotInclude(res.body.content.copticText, "<reason_long>");
+                    Validators.validateDoesNotInclude(res.body.content.englishText, "<reason_long>");
+                    done();
+                });
+        });
+
+        it("should get a season service hymn content (text) with reason & common content", (done) => {
+            const resourceId = `/${ResourceTypes.Seasons}/33/${ResourceTypes.Services}/24/${ResourceTypes.Hymns}/456/${ResourceTypes.Formats}/1/${ResourceTypes.Variations}/713`;
+            chai.request(server)
+                .get(resourceId)
+                .end((err, res) => {
+                    Validators.validateObjectResponse(res);
+                    Validators.validateServiceHymnFormatVariationResponse(res.body, resourceId);
+                    Validators.validateTextContentResponse(res.body.content);
+                    Validators.validateDoesNotInclude(res.body.content.arabicText, "<common=");
+                    Validators.validateDoesNotInclude(res.body.content.copticText, "<common=");
+                    Validators.validateDoesNotInclude(res.body.content.englishText, "<common=");
+                    Validators.validateDoesNotInclude(res.body.content.arabicText, "<reason_");
+                    Validators.validateDoesNotInclude(res.body.content.copticText, "<reason_");
+                    Validators.validateDoesNotInclude(res.body.content.englishText, "<reason_");
+                    done();
+                });
+        });
+
+        it("should get a season service hymn variation (hazzat)", (done) => {
             const resourceId = `/${ResourceTypes.Seasons}/1/${ResourceTypes.Services}/15/${ResourceTypes.Hymns}/311/${ResourceTypes.Formats}/2/${ResourceTypes.Variations}/379`;
             chai.request(server)
                 .get(resourceId)
@@ -751,7 +901,22 @@ describe("Seasons controller", () => {
                 });
         });
 
-        it("should get a season service hymn format contents (vertical hazzat)", (done) => {
+        it("should get a season service hymn variation (hazzat) with common content", (done) => {
+            const resourceId = `/${ResourceTypes.Seasons}/1/${ResourceTypes.Services}/21/${ResourceTypes.Hymns}/377/${ResourceTypes.Formats}/2/${ResourceTypes.Variations}/436`;
+            chai.request(server)
+                .get(resourceId)
+                .end((err, res) => {
+                    Validators.validateObjectResponse(res);
+                    Validators.validateServiceHymnFormatVariationResponse(res.body, resourceId);
+                    Validators.validateHazzatContentResponse(res.body.content);
+                    Validators.validateDoesNotInclude(res.body.content.arabicHazzat, "<common=");
+                    Validators.validateDoesNotInclude(res.body.content.copticHazzat, "<common=");
+                    Validators.validateDoesNotInclude(res.body.content.englishHazzat, "<common=");
+                    done();
+                });
+        });
+
+        it("should get a season service hymn format variation (vertical hazzat)", (done) => {
             const resourceId = `/${ResourceTypes.Seasons}/1/${ResourceTypes.Services}/2/${ResourceTypes.Hymns}/279/${ResourceTypes.Formats}/3/${ResourceTypes.Variations}/622`;
             chai.request(server)
                 .get(resourceId)
@@ -763,7 +928,22 @@ describe("Seasons controller", () => {
                 });
         });
 
-        it("should return a 501 for unsupported season service hymn format contents (Musical Notes)", (done) => {
+        it("should get a season service hymn format variation (vertical hazzat) with common content", (done) => {
+            const resourceId = `/${ResourceTypes.Seasons}/1/${ResourceTypes.Services}/21/${ResourceTypes.Hymns}/377/${ResourceTypes.Formats}/3/${ResourceTypes.Variations}/546`;
+            chai.request(server)
+                .get(resourceId)
+                .end((err, res) => {
+                    Validators.validateObjectResponse(res);
+                    Validators.validateServiceHymnFormatVariationResponse(res.body, resourceId);
+                    Validators.validateVerticalHazzatContentResponse(res.body.content);
+                    Validators.validateDoesNotInclude(res.body.content.arabicVerticalHazzat, "<common=");
+                    Validators.validateDoesNotInclude(res.body.content.copticVerticalHazzat, "<common=");
+                    Validators.validateDoesNotInclude(res.body.content.englishVerticalHazzat, "<common=");
+                    done();
+                });
+        });
+
+        it("should return a 501 for unsupported season service hymn format variation (Musical Notes)", (done) => {
             chai.request(server)
                 .get(`/${ResourceTypes.Seasons}/32/${ResourceTypes.Services}/17/${ResourceTypes.Hymns}/334/${ResourceTypes.Formats}/4/${ResourceTypes.Variations}/639`)
                 .end((err, res) => {
@@ -772,7 +952,7 @@ describe("Seasons controller", () => {
                 });
         });
 
-        it("should return a 501 for unsupported season service hymn format contents (Audio)", (done) => {
+        it("should return a 501 for unsupported season service hymn format variation (Audio)", (done) => {
             chai.request(server)
                 .get(`/${ResourceTypes.Seasons}/14/${ResourceTypes.Services}/4/${ResourceTypes.Hymns}/162/${ResourceTypes.Formats}/5/${ResourceTypes.Variations}/703`)
                 .end((err, res) => {
@@ -781,7 +961,7 @@ describe("Seasons controller", () => {
                 });
         });
 
-        it("should get a season service hymn format contents (video)", (done) => {
+        it("should get a season service hymn format variation (video)", (done) => {
             const resourceId = `/${ResourceTypes.Seasons}/14/${ResourceTypes.Services}/4/${ResourceTypes.Hymns}/162/${ResourceTypes.Formats}/6/${ResourceTypes.Variations}/704`;
             chai.request(server)
                 .get(resourceId)
@@ -793,7 +973,7 @@ describe("Seasons controller", () => {
                 });
         });
 
-        it("should get a season service hymn format contents (information)", (done) => {
+        it("should get a season service hymn format variation (information)", (done) => {
             const resourceId = `/${ResourceTypes.Seasons}/14/${ResourceTypes.Services}/4/${ResourceTypes.Hymns}/162/${ResourceTypes.Formats}/7/${ResourceTypes.Variations}/705`;
             chai.request(server)
                 .get(resourceId)
@@ -841,7 +1021,7 @@ describe("Seasons controller", () => {
                 });
         });
 
-        it("should return a 404 for negative service hymn format content ids", (done) => {
+        it("should return a 404 for negative service hymn format variation ids", (done) => {
             chai.request(server)
                 .get(`/${ResourceTypes.Seasons}/1/${ResourceTypes.Services}/15/${ResourceTypes.Hymns}/311/${ResourceTypes.Formats}/1/${ResourceTypes.Variations}/-1`)
                 .end((err, res) => {
@@ -886,7 +1066,7 @@ describe("Seasons controller", () => {
                 });
         });
 
-        it("should return a 404 for non integer service hymn format content ids", (done) => {
+        it("should return a 404 for non integer service hymn format variation ids", (done) => {
             chai.request(server)
                 .get(`/${ResourceTypes.Seasons}/1/${ResourceTypes.Services}/15/${ResourceTypes.Hymns}/311/${ResourceTypes.Formats}/1/${ResourceTypes.Variations}/badInput`)
                 .end((err, res) => {


### PR DESCRIPTION
Common is common content that could be injected into multiple hymns by reference.
Reason is the reason for the season (eg: came, risen, born, etc...)

This change replaces references to common content & reason with actual content.
Added unit tests